### PR TITLE
suggest amqp lib and do not require it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,10 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
-        "videlalvaro/php-amqplib": "2.2.6"
+        "php": ">=5.3.2"
+    },
+    "suggest": {
+        "php-amqplib/php-amqplib": "Allow testing a rabbitmq connection"
     },
     "autoload": {
         "classmap": [ "src/" ]


### PR DESCRIPTION
- amqp lib was required in composer.json but it is not, I added a suggestion
- videlalvaro/php-amqplib has changed and it is called php-amqplib/php-amqplib now